### PR TITLE
Automatically manage FEX rootfs

### DIFF
--- a/crates/krun/src/cli_options.rs
+++ b/crates/krun/src/cli_options.rs
@@ -13,6 +13,7 @@ pub struct Options {
     pub mem: Option<MiB>,
     pub passt_socket: Option<PathBuf>,
     pub server_port: u32,
+    pub fex_images: Vec<String>,
     pub command: PathBuf,
     pub command_args: Vec<String>,
 }
@@ -66,6 +67,15 @@ pub fn options() -> OptionParser<Options> {
         )
         .argument("MEM")
         .optional();
+    let fex_images = long("fex-image")
+        .short('f')
+        .help(
+            "Adds an erofs file to be mounted as a FEX rootfs.
+            May be specified multiple times.
+            First the base image, then overlays in order.",
+        )
+        .argument::<String>("FEX_IMAGE")
+        .many();
     let passt_socket = long("passt-socket")
         .help("Instead of starting passt, connect to passt socket at PATH")
         .argument("PATH")
@@ -89,6 +99,7 @@ pub fn options() -> OptionParser<Options> {
         mem,
         passt_socket,
         server_port,
+        fex_images,
         // positionals
         command,
         command_args,

--- a/crates/krun/src/guest/mount.rs
+++ b/crates/krun/src/guest/mount.rs
@@ -1,22 +1,101 @@
-use std::fs::File;
+use std::ffi::CString;
+use std::fs::{read_dir, File};
+use std::io::Write;
 use std::os::fd::AsFd;
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use rustix::fs::CWD;
+use rustix::fs::{mkdir, symlink, Mode, CWD};
 use rustix::mount::{
     mount2, mount_bind, move_mount, open_tree, MountFlags, MoveMountFlags, OpenTreeFlags,
 };
 
-pub fn mount_filesystems() -> Result<()> {
+fn make_tmpfs(dir: &str) -> Result<()> {
     mount2(
         Some("tmpfs"),
-        "/var/run",
+        dir,
         Some("tmpfs"),
         MountFlags::NOEXEC | MountFlags::NOSUID | MountFlags::RELATIME,
         None,
     )
-    .context("Failed to mount `/var/run`")?;
+    .context("Failed to mount tmpfs")
+}
+
+fn mkdir_fex(dir: &str) {
+    // Must succeed since /run/ was just mounted and is now an empty tmpfs.
+    mkdir(
+        dir,
+        Mode::RUSR | Mode::XUSR | Mode::RGRP | Mode::XGRP | Mode::ROTH | Mode::XOTH,
+    )
+    .unwrap();
+}
+
+fn mount_fex_rootfs() -> Result<()> {
+    let dir = "/run/fex-emu/";
+    let dir_rootfs = dir.to_string() + "rootfs";
+
+    // Make base directories
+    mkdir_fex(dir);
+
+    let flags = MountFlags::RDONLY;
+    let mut images = Vec::new();
+
+    // Find /dev/vd*
+    for x in read_dir("/dev").unwrap() {
+        let file = x.unwrap();
+        let name = file.file_name().into_string().unwrap();
+        if !name.starts_with("vd") {
+            continue;
+        }
+
+        let path = file.path().into_os_string().into_string().unwrap();
+        let dir = dir.to_string() + &name;
+
+        // Mount the erofs images.
+        mkdir_fex(&dir);
+        mount2(Some(path), dir.clone(), Some("erofs"), flags, None)
+            .context("Failed to mount erofs")
+            .unwrap();
+        images.push(dir);
+    }
+
+    if images.len() >= 2 {
+        // Overlay the mounts together.
+        let opts = format!(
+            "lowerdir={}",
+            images.into_iter().rev().collect::<Vec<String>>().join(":")
+        );
+        let opts = CString::new(opts).unwrap();
+        let overlay = "overlay".to_string();
+        let overlay_ = Some(&overlay);
+
+        mkdir_fex(&dir_rootfs);
+        mount2(overlay_, &dir_rootfs, overlay_, flags, Some(&opts)).context("Failed to overlay")?;
+    } else if images.len() == 1 {
+        // Just expose the one mount
+        symlink(&images[0], &dir_rootfs)?;
+    }
+
+    // Now we need to tell FEX about this. One of the FEX share directories has an unmounted rootfs
+    // and a Config.json telling FEX to use FUSE. Neither should be visible to the guest. Instead,
+    // we want to replace the folders and tell FEX to use our mounted rootfs
+    for base in ["/usr/share/fex-emu", "/usr/local/share/fex-emu"] {
+        let json = format!("{{\"Config\":{{\"RootFS\":\"{dir_rootfs}\"}}}}\n");
+        let path = base.to_string() + "/Config.json";
+
+        make_tmpfs(base)?;
+        File::create(Path::new(&path))?.write_all(json.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+pub fn mount_filesystems() -> Result<()> {
+    make_tmpfs("/var/run")?;
+
+    if let Err(_) = mount_fex_rootfs() {
+        println!("Failed to mount FEX rootfs, carrying on without.")
+    }
 
     let _ = File::options()
         .write(true)
@@ -60,14 +139,7 @@ pub fn mount_filesystems() -> Result<()> {
     if Path::new("/tmp/.X11-unix").exists() {
         // Mount a tmpfs for X11 sockets, so the guest doesn't clobber host X server
         // sockets
-        mount2(
-            Some("tmpfs"),
-            "/tmp/.X11-unix",
-            Some("tmpfs"),
-            MountFlags::NOEXEC | MountFlags::NOSUID | MountFlags::RELATIME,
-            None,
-        )
-        .context("Failed to mount `/tmp/.X11-unix`")?;
+        make_tmpfs("/tmp/.X11-unix")?;
     }
 
     Ok(())


### PR DESCRIPTION
This adds a mechanism for automatically managing the FEX rootfs, mounting and overlayfs'ing the relevant squashfs files from the host.

Depends on:

 * libkrun https://github.com/containers/libkrun/pull/217
 * libkrunfw https://github.com/containers/libkrunfw/pull/65