### PR TITLE
Pass --direct-scale and --log-level to sommelier

### DIFF
--- a/crates/krun/src/guest/sommelier.rs
+++ b/crates/krun/src/guest/sommelier.rs
@@ -21,7 +21,13 @@ where
     let gl_env = env::var("LIBGL_DRIVERS_PATH").ok();
 
     let mut cmd = Command::new(sommelier_path);
-    cmd.args(["--virtgpu-channel", "-X", "--glamor"]);
+    cmd.args([
+        "--virtgpu-channel",
+        "-X",
+        "--direct-scale",
+        "--log-level=3",
+        "--glamor",
+    ]);
 
     if let Some(gl_env) = gl_env {
         cmd.arg(format!("--xwayland-gl-driver-path={gl_env}"));


### PR DESCRIPTION
With HiDPI screens, some games running in sommelier may scale way beyond the actual screen size. Passing --direct-scale to sommelier fixes this.

While there, also pass --log-level=3 to reduce sommelier's verbosity which was increased in the latest versions.