### PR TITLE
Split FEX mesa overlay into i386 and x86_64 overlays

### DIFF
--- a/crates/krun/src/bin/krun.rs
+++ b/crates/krun/src/bin/krun.rs
@@ -167,7 +167,8 @@ fn main() -> Result<()> {
     } else {
         let default_disks = [
             "/usr/share/fex-emu/RootFS/default.erofs",
-            "/usr/share/fex-emu/overlays/mesa.erofs",
+            "/usr/share/fex-emu/overlays/mesa-i386.erofs",
+            "/usr/share/fex-emu/overlays/mesa-x86_64.erofs",
         ];
 
         default_disks


### PR DESCRIPTION
With https://pagure.io/fedora-asahi/mesa/pull-request/21 the mesa overlay is splitted into i386 and x86_64 as they are generated during the main mesa build.